### PR TITLE
Improve nextflow implementation

### DIFF
--- a/nextflow/example.nf
+++ b/nextflow/example.nf
@@ -1,58 +1,51 @@
 #!/usr/bin/env nextflow
-
-// help message
-def helpMessage() {
-    log.info"""
-    Usage:
-
-        nextflow run example.nf --ref ref.fasta[.gz] --left path/to/reads_1.fastq --right path/to/reads_2.fastq --outdir path/to/resultdir
-
-    --ref       Path to reference transcript (fasta[.gz])
-    --left      Path to left strand (fastq)
-    --right     Path to right strand (fastq)
-    --outdir    Output directory (where output results will be saved)  
-    --help      Displays usage message  
-
-    """.stripIndent()
-}
-
-// Show help message
-if (params.help) {
-    helpMessage()
-    exit 0
-}
+params.ref = 'path/to/ref.fasta'
+params.left = 'path/to/reads_1.fastq'
+params.right = 'path/to/reads_2.fastq'
+params.outdir = 'results'
 
 
 // Create reference transcriptome index using Salmom
 process salmonIndex {
-
+    input: 
+    path ref from params.ref
     output:
-    file index into txome_index
+    path index into txome_index
 
     """
-    salmon index -t '${params.ref}' -i index
+    salmon index -t '${ref}' -i index
     """
 }
 
 
 // Transcriptome alignment and quantification using Salmon
 process salmonAlignQuant {
+    publishDir params.outdir
 
     input:
-    file index from txome_index
+      path index from txome_index
+      path left from params.left
+      path right from params.right
+    output:
+      path 'quant'
 
     """
-    salmon quant -i $index -l A -1 '${params.left}' -2 '${params.right}' --validateMappings -o '${params.outdir}'
+    salmon quant -i $index -l A -1 '${left}' -2 '${right}' --validateMappings -o quant
     """
 }
 
 // FastQC
 process fastQC {
+    publishDir params.outdir
 
+    input:
+      path index from txome_index
+      path left from params.left
+      path right from params.right
     output:
-    stdout result
+      path 'qc'
 
     """
-    fastqc --quiet '${params.left}' '${params.right}' --outdir '${params.outdir}'
+    mkdir qc && fastqc --quiet '${params.left}' '${params.right}' --outdir qc
     """
 }


### PR DESCRIPTION
This commit improves the nextflow implementation in several aspects:
- use `path` instead of `file` in input/output declaration
- properly declares inputs instead of using `params`
- use `publishDir` to generate expected pipeline output files
- declare pipeline params at the top of the script
- remove help custom function to make uniform with other implementations

If you are happy with these changes, I can modify the script to make it DSL2 complaint. 

Also, consider including in this repo the test dataset and the Dockerfile for the required tool dependency. 